### PR TITLE
make pad_token_id accept tokenizer directly

### DIFF
--- a/examples/fsdp2_training/train_math_fsdp2.py
+++ b/examples/fsdp2_training/train_math_fsdp2.py
@@ -263,8 +263,6 @@ def main() -> None:
 
     # Tokenizer + model
     tokenizer = AutoTokenizer.from_pretrained(args.model)
-    if tokenizer.pad_token_id is None:
-        tokenizer.pad_token_id = tokenizer.eos_token_id
     chat_template = HFChatTemplate(tokenizer)
 
     mp_policy = fsdp.MixedPrecisionPolicy(
@@ -364,7 +362,7 @@ def main() -> None:
         max_seq_len=args.max_seq_len,
         micro_token_budget=args.micro_token_budget,
         max_grad_norm=0.5,
-        pad_token_id=tokenizer.pad_token_id,
+        pad_token_id=tokenizer,
         reduce_stats_across_ranks=True,
         eval_at_start=bool(args.eval_before_start and do_eval),
         eval_every_n_steps=(int(args.eval_every) if args.eval_every and args.eval_every > 0 and do_eval else None),

--- a/examples/gsm8k/train_gsm8k.py
+++ b/examples/gsm8k/train_gsm8k.py
@@ -127,8 +127,6 @@ def main():
 
     # Tokenizer + model
     tokenizer = AutoTokenizer.from_pretrained(args.model)
-    if tokenizer.pad_token_id is None:
-        tokenizer.pad_token_id = tokenizer.eos_token_id
     model = AutoModelForCausalLM.from_pretrained(args.model, dtype=torch.bfloat16)
     model.to("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -205,7 +203,7 @@ def main():
         max_seq_len=args.max_seq_len,
         micro_token_budget=args.micro_token_budget,
         max_grad_norm=0.5,
-        pad_token_id=tokenizer.pad_token_id,
+        pad_token_id=tokenizer,
         eval_at_start=bool(args.eval_before_start and eval_samples),
         eval_every_n_steps=(args.eval_every if args.eval_every and args.eval_every > 0 and eval_samples else None),
         eval_concurrency=args.eval_concurrency,

--- a/examples/tic_tac_toe/sft_tic_tac_toe.py
+++ b/examples/tic_tac_toe/sft_tic_tac_toe.py
@@ -196,8 +196,6 @@ def main() -> None:
         return
 
     tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
-    if tokenizer.pad_token_id is None:
-        tokenizer.pad_token_id = tokenizer.eos_token_id
 
     mp_policy = fsdp.MixedPrecisionPolicy(
         param_dtype=torch.bfloat16,
@@ -264,7 +262,7 @@ def main() -> None:
         max_seq_len=args.max_seq_len,
         micro_token_budget=args.micro_token_budget,
         max_grad_norm=args.max_grad_norm,
-        pad_token_id=tokenizer.pad_token_id,
+        pad_token_id=tokenizer,
         lr=args.lr,
         reduce_stats_across_ranks=True,
         eval_at_start=False,

--- a/examples/tic_tac_toe/train_tic_tac_toe.py
+++ b/examples/tic_tac_toe/train_tic_tac_toe.py
@@ -175,8 +175,6 @@ def main():
 
     # Tokenizer + model
     tokenizer = AutoTokenizer.from_pretrained(args.model)
-    if tokenizer.pad_token_id is None:
-        tokenizer.pad_token_id = tokenizer.eos_token_id
     chat_template = HFChatTemplate(tokenizer)
     base_model = AutoModelForCausalLM.from_pretrained(
         args.model,
@@ -273,7 +271,7 @@ def main():
         max_seq_len=args.max_seq_len,
         micro_token_budget=args.micro_token_budget,
         max_grad_norm=0.5,
-        pad_token_id=tokenizer.pad_token_id,
+        pad_token_id=tokenizer,
         lr=5e-5,
         eval_at_start=bool(args.eval_before_start and args.eval_episodes and args.eval_episodes > 0),
         eval_every_n_steps=(args.eval_every if args.eval_every and args.eval_every > 0 else None),

--- a/src/ludic/training/config.py
+++ b/src/ludic/training/config.py
@@ -1,5 +1,17 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, Optional, Union
+
+
+def _extract_pad_token_id(tokenizer: Any) -> int:
+    """Extract pad_token_id from a tokenizer, with eos_token_id fallback."""
+    if (pad := getattr(tokenizer, "pad_token_id", None)) is not None:
+        return pad
+    if (eos := getattr(tokenizer, "eos_token_id", None)) is not None:
+        return eos
+    raise ValueError(
+        "Tokenizer has no pad_token_id or eos_token_id. "
+        "Set tokenizer.pad_token_id explicitly before passing to TrainerConfig."
+    )
 
 
 @dataclass
@@ -9,6 +21,16 @@ class TrainerConfig:
 
     This is *purely* about optimization / model device / collation.
     Rollout and batch-generation config live in BatchSource / Orchestrator.
+
+    ==========================
+    Required
+    ==========================
+
+    - pad_token_id:
+          Token ID used when padding sequences during SAW collation.
+          Pass your tokenizer directly and the pad_token_id will be
+          extracted automatically (with eos_token_id as fallback).
+          You can also pass an int if you know the exact token ID.
 
     ==========================
     Model / Optimization
@@ -31,27 +53,20 @@ class TrainerConfig:
 
     - max_seq_len:
           Max token length for any single sample. Trainer raises if exceeded.
-          
+
     - micro_token_budget:
           Max padded tokens per micro-batch (roughly batch_size * max_seq_len).
           Trainer splits macro-batches into micro-batches that fit this budget.
           Must be >= max_seq_len.
-          
+
     - sync_every_steps:
-          Frequency (in macro-steps) at which to push updated policy 
+          Frequency (in macro-steps) at which to push updated policy
           weights to the Agent's runtime (e.g., vLLM). Set to 0 to disable
           syncing (e.g., pure offline/local training).
 
     - mixed_precision_dtype:
-          Optional string to configure FSDP's mixed precision policy. 
+          Optional string to configure FSDP's mixed precision policy.
           Use "bf16" or "fp16". If None, defaults to full precision (fp32).
-
-    ==========================
-    Collation
-    ==========================
-
-    - pad_token_id:
-          Used when padding sequences during SAW collation.
 
     ==========================
     Distributed
@@ -90,6 +105,9 @@ class TrainerConfig:
           Optional per-call timeout for eval rollouts.
     """
 
+    # ----- required (no default) ------------------
+    pad_token_id: Union[int, Any]  # int or tokenizer-like object
+
     # ----- model / optimization -------------------
     model_device: str = "cuda"
     runtime_device: Optional[str] = None
@@ -113,12 +131,13 @@ class TrainerConfig:
     profile_memory: bool = False
     log_every: int = 1
 
-    # ----- collation ------------------------------
-    pad_token_id: int = 0
-
     # ----- evaluation -----------------------------
     eval_at_start: bool = False
     eval_every_n_steps: Optional[int] = None
     eval_concurrency: int = 32
     eval_max_steps: int = 1
     eval_timeout_s: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.pad_token_id, int):
+            self.pad_token_id = _extract_pad_token_id(self.pad_token_id)

--- a/src/ludic/training/trainer.py
+++ b/src/ludic/training/trainer.py
@@ -70,8 +70,8 @@ class Trainer:
         model: nn.Module,
         algo: RLAlgorithm,
         batch_source: BatchSource,
+        cfg: TrainerConfig,
         publisher: Optional[PolicyPublisher] = None,
-        cfg: TrainerConfig = TrainerConfig(),
         param_filter: Optional[Callable[[str, Tensor], bool]] = None,
         enable_gradient_checkpointing: bool = False,
         checkpointer: Optional[CheckpointManager] = None,
@@ -96,13 +96,13 @@ class Trainer:
                 The SAWBatch is treated as a macro-batch and split into
                 micro-batches for gradient accumulation.
 
-            publisher:
-                Abstract interface to push weights to inference workers. If None, weight
-                syncing is disabled.
-
             cfg:
                 TrainerConfig for device, optimizer hyperparams, pad_token_id,
                 micro_token_budget, max_seq_len, and sync_every_steps.
+
+            publisher:
+                Abstract interface to push weights to inference workers. If None, weight
+                syncing is disabled.
 
             param_filter:
                 Optional predicate (name, Tensor) -> bool deciding which
@@ -697,8 +697,6 @@ class Trainer:
             raise ValueError(
                 "Trainer evaluation requested (eval_at_start or eval_every_n_steps) but no evaluator was provided."
             )
-        if self.cfg.pad_token_id is None:
-            raise ValueError("TrainerConfig.pad_token_id must be set for collation.")
         if self.cfg.max_seq_len < 1:
             raise ValueError("TrainerConfig.max_seq_len must be >= 1.")
         if self.cfg.micro_token_budget <= 0:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -104,6 +104,24 @@ def _trainer_for_batch(
     )
 
 
+def test_trainer_config_extracts_pad_token_from_tokenizer():
+    """TrainerConfig accepts a tokenizer and extracts pad_token_id."""
+    # Mock tokenizer with pad_token_id
+    tokenizer = SimpleNamespace(pad_token_id=42, eos_token_id=1)
+    cfg = TrainerConfig(pad_token_id=tokenizer, model_device="cpu")
+    assert cfg.pad_token_id == 42
+
+    # Falls back to eos_token_id if pad_token_id is None
+    tokenizer_no_pad = SimpleNamespace(pad_token_id=None, eos_token_id=99)
+    cfg2 = TrainerConfig(pad_token_id=tokenizer_no_pad, model_device="cpu")
+    assert cfg2.pad_token_id == 99
+
+    # Raises if neither is set
+    tokenizer_neither = SimpleNamespace(pad_token_id=None, eos_token_id=None)
+    with pytest.raises(ValueError, match="pad_token_id"):
+        TrainerConfig(pad_token_id=tokenizer_neither, model_device="cpu")
+
+
 def test_trainer_requires_publisher_with_sync():
     batch = SAWBatch(items=[_make_item(2, 1.0)], meta={})
     with pytest.raises(ValueError, match="PolicyPublisher"):


### PR DESCRIPTION
TrainerConfig now accepts either an int or a tokenizer object for pad_token_id. When a tokenizer is passed, the pad_token_id is extracted automatically with eos_token_id as fallback.

This eliminates boilerplate in training scripts:
- Before: if tokenizer.pad_token_id is None: ...
- After: TrainerConfig(pad_token_id=tokenizer, ...)

Also makes pad_token_id a required argument (no default) to prevent the footgun of silently using token ID 0.

Fixes #11 .